### PR TITLE
Speed up! Immutable data and PureRenderMixin

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "browserify": "^8.0.3",
     "clean-css": "^3.1.9",
     "eslint": "^0.14.1",
+    "immutable": "^3.7.4",
     "pushstate-server": "^1.6.0",
     "rework": "^1.0.1",
     "rework-npm": "^1.0.0",

--- a/src/components/User.jsx
+++ b/src/components/User.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactMixin from 'react-mixin';
 import UserStore from '../stores/UserStore';
 import EventStore from '../stores/EventStore';
 import UserService from '../services/UserService';
@@ -51,3 +52,5 @@ export default class User extends React.Component {
     );
   }
 }
+
+ReactMixin(User.prototype, React.addons.PureRenderMixin);

--- a/src/components/User.jsx
+++ b/src/components/User.jsx
@@ -40,11 +40,11 @@ export default class User extends React.Component {
   }
 
   render() {
-    var cal = !this.state.user.born ? '' :
-      <WholeLife user={this.state.user} events={this.state.events} />
+    var cal = !this.state.user.get('born') ? '' :
+      <WholeLife events={this.state.events} />
     return (
       <div>
-        <h1>{this.state.user.name} <small>A life</small></h1>
+        <h1>{this.state.user.get('name')} <small>A life</small></h1>
         <RouteHandler/>
         {cal}
       </div>

--- a/src/components/Week.jsx
+++ b/src/components/Week.jsx
@@ -25,7 +25,7 @@ export default class Week extends React.Component {
     }
     return (
       <span data-tooltip={tooltip}>
-        <Link to="week" params={{slug: UserStore.user.slug, start: this.dateParam(this.props.start), end: this.dateParam(this.props.end)}}>
+        <Link to="week" params={{slug: UserStore.user.get('slug'), start: this.dateParam(this.props.start), end: this.dateParam(this.props.end)}}>
           {emoji}
         </Link>
       </span>

--- a/src/components/Week.jsx
+++ b/src/components/Week.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Emoji from 'node-emoji';
-import EventStore from '../stores/EventStore';
 import UserStore from '../stores/UserStore';
 import { Link } from 'react-router';
 
@@ -19,9 +18,9 @@ export default class Week extends React.Component {
   emojiFor(events) {
     let tooltip = this.props.start.toDateString();
     let emoji = <span className="placeholder"/>;
-    if (events[0]) {
-      tooltip = `${tooltip}: ${events[0].summary}`;
-      emoji = Emoji.get(events[0].emoji);
+    if (events.first()) {
+      tooltip = `${tooltip}: ${events.first().get('summary')}`;
+      emoji = Emoji.get(events.first().get('emoji'));
     }
     return (
       <span data-tooltip={tooltip}>

--- a/src/components/Week.jsx
+++ b/src/components/Week.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactMixin from 'react-mixin';
 import Emoji from 'node-emoji';
 import UserStore from '../stores/UserStore';
 import { Link } from 'react-router';
@@ -35,3 +36,5 @@ export default class Week extends React.Component {
     return date.toJSON().split('T')[0]
   }
 }
+
+ReactMixin(Week.prototype, React.addons.PureRenderMixin);

--- a/src/components/WholeLife.jsx
+++ b/src/components/WholeLife.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import Year from './Year';
+import UserStore from '../stores/UserStore';
 
 export default class WholeLife extends React.Component {
   render() {
     var years = [],
-        born = this.props.user.born;
+        born = UserStore.user.get('born');
 
     for(var i=0; i<=100; i++) {
       let year = born.getFullYear() + i;

--- a/src/components/WholeLife.jsx
+++ b/src/components/WholeLife.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactMixin from 'react-mixin';
 import Year from './Year';
 import UserStore from '../stores/UserStore';
 
@@ -25,3 +26,5 @@ export default class WholeLife extends React.Component {
     );
   }
 }
+
+ReactMixin(WholeLife.prototype, React.addons.PureRenderMixin);

--- a/src/components/WholeLife.jsx
+++ b/src/components/WholeLife.jsx
@@ -13,7 +13,7 @@ export default class WholeLife extends React.Component {
         <Year
           key={i}
           birthYear={born.getFullYear()}
-          events={this.props.events[year]}
+          events={this.props.events.get(year)}
           start={new Date(year, born.getMonth(), born.getDate())}
         />
       )

--- a/src/components/Year.jsx
+++ b/src/components/Year.jsx
@@ -22,7 +22,7 @@ export default class Year extends React.Component {
   }
 
   eventsFor(start, end) {
-    return this.props.events.filter(e => e.date >= start && e.date < end);
+    return this.props.events.filter(e => e.get('date') >= start && e.get('date') < end);
   }
 
   addDaysTo(date, days, notAfter) {

--- a/src/components/Year.jsx
+++ b/src/components/Year.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactMixin from 'react-mixin';
 import Week from './Week';
 
 export default class Year extends React.Component {
@@ -31,3 +32,5 @@ export default class Year extends React.Component {
     else return notAfter
   }
 }
+
+ReactMixin(Year.prototype, React.addons.PureRenderMixin);

--- a/src/stores/EventStore.js
+++ b/src/stores/EventStore.js
@@ -33,21 +33,21 @@ class EventStore extends BaseStore {
   }
 
   _calculatedEvents() {
-    if (UserStore.user.id) return this._userBirthdays()
+    if (UserStore.user.get('id')) return this._userBirthdays()
     else return []
   }
 
   _userBirthdays() {
     var birthdays = [];
-    birthdays.push({ summary: "It's a baby!", emoji: 'baby', date: UserStore.user.born })
+    birthdays.push({ summary: "It's a baby!", emoji: 'baby', date: UserStore.user.get('born') })
     for (var i = 1; i < 100; i++) {
       birthdays.push({
         summary: 'Happy Birthday #' + i,
         emoji: 'birthday',
-        date: this._addYearsTo(UserStore.user.born, i)
+        date: this._addYearsTo(UserStore.user.get('born'), i)
       });
     }
-    birthdays.push({ summary: 'Happy Birthday #100', emoji: '100', date: this._addYearsTo(UserStore.user.born, 100)})
+    birthdays.push({ summary: 'Happy Birthday #100', emoji: '100', date: this._addYearsTo(UserStore.user.get('born'), 100)})
     return birthdays;
   }
 

--- a/src/stores/EventStore.js
+++ b/src/stores/EventStore.js
@@ -1,19 +1,20 @@
 import {EVENTS_GET} from '../constants/EventConstants';
 import BaseStore from './BaseStore';
 import UserStore from './UserStore';
+import { Map, List, Range } from 'immutable';
 
 class EventStore extends BaseStore {
 
   constructor() {
     super();
     this.subscribe(() => this._registerToActions.bind(this))
-    this._userEvents = [];
+    this._userEvents = List();
   }
 
   _registerToActions(action) {
     switch(action.actionType) {
       case EVENTS_GET:
-        this._userEvents = this.castDates(action.events);
+        this._userEvents = this.makeImmutable(action.events);
         this.emitChange();
         break;
       default:
@@ -21,34 +22,31 @@ class EventStore extends BaseStore {
     };
   }
 
-  castDates(events) {
-    return events.map(e => {
-      e.date = new Date(e.date.split('-'));
-      return e;
-    })
+  makeImmutable(events) {
+    return List(
+      events.map(e => Map(e).update('date', str => new Date(str.split('-')) ))
+    )
   }
 
-  makeDateFrom(someString) {
-    return new Date(someString.split('-').map(x => parseInt(x)))
+  get _calculatedEvents() {
+    return this.userBirthdays
   }
 
-  _calculatedEvents() {
-    if (UserStore.user.get('id')) return this._userBirthdays()
-    else return []
-  }
-
-  _userBirthdays() {
-    var birthdays = [];
-    birthdays.push({ summary: "It's a baby!", emoji: 'baby', date: UserStore.user.get('born') })
-    for (var i = 1; i < 100; i++) {
-      birthdays.push({
-        summary: 'Happy Birthday #' + i,
-        emoji: 'birthday',
-        date: this._addYearsTo(UserStore.user.get('born'), i)
-      });
+  get userBirthdays() {
+    if (!UserStore.user.get('born')) return List();
+    else {
+      if (this._userBirthdays) return this._userBirthdays;
+      this._userBirthdays = this.calculateBirthdays;
+      return this._userBirthdays
     }
-    birthdays.push({ summary: 'Happy Birthday #100', emoji: '100', date: this._addYearsTo(UserStore.user.get('born'), 100)})
-    return birthdays;
+  }
+
+  get calculateBirthdays() {
+    return Range(0,101).map(i => Map({
+      summary: i === 0 ? "It's a baby!" : `Happy Birthday #${i}`,
+      emoji: i === 0 ? "baby" : i === 100 ? "100" : "birthday",
+      date: this._addYearsTo(UserStore.user.get('born'), i)
+    }))
   }
 
   _addYearsTo(date, years) {
@@ -56,16 +54,11 @@ class EventStore extends BaseStore {
   }
 
   get events() {
-    return this._userEvents.concat(this._calculatedEvents());
+    return this._userEvents.concat(this._calculatedEvents);
   }
 
   get eventsByYear() {
-    let grouped = {};
-    this.events.forEach(e => {
-      if (grouped[e.date.getFullYear()]) grouped[e.date.getFullYear()].push(e)
-      else grouped[e.date.getFullYear()] = [e]
-    })
-    return grouped
+    return this.events.groupBy(event => event.get('date').getFullYear());
   }
 }
 

--- a/src/stores/UserStore.js
+++ b/src/stores/UserStore.js
@@ -1,28 +1,24 @@
 import {USER_GET} from '../constants/UserConstants';
 import BaseStore from './BaseStore';
+import { Map } from 'immutable';
 
 class UserStore extends BaseStore {
 
   constructor() {
     super();
     this.subscribe(() => this._registerToActions.bind(this))
-    this._user = {id: null, name: null, email: null, slug: null, born: null};
+    this._user = Map({id: null, name: null, email: null, slug: null, born: null});
   }
 
   _registerToActions(action) {
     switch(action.actionType) {
       case USER_GET:
-        this._user = action.user;
-        this._user.born = this.makeDateFrom(this._user.born);
+        this._user = Map(action.user).update('born', str => new Date(str.split('-')));
         this.emitChange();
         break;
       default:
         break;
     };
-  }
-
-  makeDateFrom(someString) {
-    return new Date(someString.split('-').map(x => parseInt(x)))
   }
 
   get user() {


### PR DESCRIPTION
Re-rendering everything all the time is silly.

The PureRenderMixin checks the new state & props against the old state & props, and only updates if things have changed.

For it to compare complex data structures, those structures must be immutable. So here it is!
